### PR TITLE
Move gallery page with map redirect

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders gallery heading', () => {
+test('renders world map on home page', () => {
+  window.history.pushState({}, 'Home', '/');
+  render(<App />);
+  const map = screen.getByAltText(/world map/i);
+  expect(map).toBeInTheDocument();
+});
+
+test('renders gallery when on gallery page', () => {
+  window.history.pushState({}, 'Gallery', '/gallery');
   render(<App />);
   const heading = screen.getByText(/photo gallery/i);
   expect(heading).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 import Gallery from './Gallery';
+import Home from './Home';
+
+const Header = () => (
+  <header className="App-header">
+    <img src={logo} className="App-logo" alt="logo" />
+    <p>Welcome to Dani's Photo Gallery</p>
+  </header>
+);
 
 function App() {
+  const base = process.env.PUBLIC_URL || '';
+  const path = window.location.pathname.replace(base, '');
+  const showGallery = path.includes('gallery');
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>Welcome to Dani's Photo Gallery</p>
-      </header>
-      <Gallery />
+      <Header />
+      {showGallery ? <Gallery /> : <Home />}
     </div>
   );
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+function Home() {
+  const goToGallery = () => {
+    const base = process.env.PUBLIC_URL || '';
+    window.location.href = `${base}/gallery`;
+  };
+
+  return (
+    <div className="home">
+      <img
+        src="https://upload.wikimedia.org/wikipedia/commons/8/80/World_map_-_low_resolution.svg"
+        alt="World Map"
+        style={{ cursor: 'pointer', maxWidth: '80%', height: 'auto' }}
+        onClick={goToGallery}
+      />
+      <p>Click a location to view the photo gallery</p>
+    </div>
+  );
+}
+
+export default Home;


### PR DESCRIPTION
## Summary
- add a new `Home` component with a world map
- display map on home page and move gallery behind `/gallery`
- update tests for new routing behaviour

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686970db085c8327ab030e9ffb04a016